### PR TITLE
Refactor tipo_vinculo_hae column to tipo_vinculo_hae_id and update TipoVinculoHAE model

### DIFF
--- a/PGA-Backend/prisma/migrations/20250602233700_create_tipovinculo_table/migration.sql
+++ b/PGA-Backend/prisma/migrations/20250602233700_create_tipovinculo_table/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `tipo_vinculo_hae` on the `ProjetoPessoa` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "ProjetoPessoa" DROP COLUMN "tipo_vinculo_hae",
+ADD COLUMN     "tipo_vinculo_hae_id" INTEGER;
+
+-- DropEnum
+DROP TYPE "TipoVinculoHAE";
+
+-- CreateTable
+CREATE TABLE "TipoVinculoHAE" (
+    "id" SERIAL NOT NULL,
+    "sigla" VARCHAR(10) NOT NULL,
+    "descricao" VARCHAR(255) NOT NULL,
+    "detalhes" TEXT,
+
+    CONSTRAINT "TipoVinculoHAE_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TipoVinculoHAE_sigla_key" ON "TipoVinculoHAE"("sigla");
+
+-- AddForeignKey
+ALTER TABLE "ProjetoPessoa" ADD CONSTRAINT "ProjetoPessoa_tipo_vinculo_hae_id_fkey" FOREIGN KEY ("tipo_vinculo_hae_id") REFERENCES "TipoVinculoHAE"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/PGA-Backend/prisma/schema.prisma
+++ b/PGA-Backend/prisma/schema.prisma
@@ -113,9 +113,10 @@ model ProjetoPessoa {
   pessoa_id             Int
   papel                 PapelProjeto
   carga_horaria_semanal Int?
-  tipo_vinculo_hae      TipoVinculoHAE @default(NaoSeAplica)
-  acaoProjeto           AcaoProjeto    @relation(fields: [acao_projeto_id], references: [acao_projeto_id])
-  pessoa                Pessoa         @relation(fields: [pessoa_id], references: [pessoa_id])
+  tipo_vinculo_hae_id   Int?            
+  tipo_vinculo_hae      TipoVinculoHAE? @relation(fields: [tipo_vinculo_hae_id], references: [id])
+  acaoProjeto           AcaoProjeto     @relation(fields: [acao_projeto_id], references: [acao_projeto_id])
+  pessoa                Pessoa          @relation(fields: [pessoa_id], references: [pessoa_id])
 }
 
 model EtapaProcesso {
@@ -229,6 +230,14 @@ model Attachment1 {
   flag                       AnexoProjetoUm
 }
 
+model TipoVinculoHAE {
+  id                    Int             @id @default(autoincrement())
+  sigla                 String          @unique @db.VarChar(10)
+  descricao             String          @db.VarChar(255)
+  detalhes              String?         @db.Text
+  projetos_pessoas      ProjetoPessoa[]
+}
+
 enum StatusPGA {
   EmElaboracao
   Submetido
@@ -245,13 +254,6 @@ enum TipoUsuario {
 enum PapelProjeto {
   Responsavel
   Colaborador
-}
-
-enum TipoVinculoHAE {
-  HAE15       @map("15")
-  HAE25       @map("25")
-  HAE40       @map("40")
-  NaoSeAplica
 }
 
 enum StatusVerificacao {


### PR DESCRIPTION
Replace the `tipo_vinculo_hae` column in the `ProjetoPessoa` table with `tipo_vinculo_hae_id`, creating a new `TipoVinculoHAE` table to manage relationships more effectively.