### PR TITLE
Refactor tests to use UUIDs for entity identification

### DIFF
--- a/PGA-Backend/src/modules/attachment/attachment.spec.ts
+++ b/PGA-Backend/src/modules/attachment/attachment.spec.ts
@@ -50,15 +50,15 @@ describe('FindAllAttachmentService', () => {
 
   it('deve filtrar por unidade', async () => {
     mockRepo.findAllByUnit.mockResolvedValue([{ attachment_id: 2 }]);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 5 } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith(5);
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-5' } });
+    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-5');
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ attachment_id: 3 }]);
-    const result = await service.execute({ active_context: { tipo: 'regional', id: 2 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(2);
+    const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-2' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-2');
     expect(result).toHaveLength(1);
   });
 });
@@ -69,13 +69,13 @@ describe('FindOneAttachmentService', () => {
 
   it('deve retornar anexo encontrado', async () => {
     mockRepo.findOneWithContext.mockResolvedValue({ anexo_id: 1 });
-    const result = await service.execute(1);
+    const result = await service.execute('uuid-1');
     expect(result).toEqual({ anexo_id: 1 });
   });
 
   it('deve retornar null se não encontrado', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    const result = await service.execute(99);
+    const result = await service.execute('uuid-99');
     expect(result).toBeNull();
   });
 });
@@ -86,14 +86,14 @@ describe('UpdateAttachmentService', () => {
 
   it('deve atualizar o anexo', async () => {
     mockRepo.update.mockResolvedValue({ anexo_id: 1, item: 'Documento' });
-    const result = await service.execute(1, { item: 'Documento' } as any);
+    const result = await service.execute('uuid-1', { item: 'Documento' } as any);
     expect((result as any).item).toBe('Documento');
   });
 
   it('deve chamar update com os dados corretos', async () => {
-    mockRepo.update.mockResolvedValue({ anexo_id: 1 });
-    await service.execute(1, {} as any);
-    expect(mockRepo.update).toHaveBeenCalledWith(1, {});
+    mockRepo.update.mockResolvedValue({ anexo_id: 'uuid-1' });
+    await service.execute('uuid-1', {} as any);
+    expect(mockRepo.update).toHaveBeenCalledWith('uuid-1', {});
   });
 });
 
@@ -104,13 +104,13 @@ describe('DeleteAttachmentService', () => {
   it('deve deletar o anexo', async () => {
     mockRepo.findOne.mockResolvedValue({ attachment_id: 1 });
     mockRepo.delete.mockResolvedValue({ attachment_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.delete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.delete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -120,14 +120,14 @@ describe('FindByDeliverableService', () => {
 
   it('deve retornar anexos do entregável', async () => {
     mockRepo.findByEntregavel.mockResolvedValue([{ attachment_id: 1 }]);
-    const result = await service.execute(5);
-    expect(mockRepo.findByEntregavel).toHaveBeenCalledWith(5);
+    const result = await service.execute('uuid-5');
+    expect(mockRepo.findByEntregavel).toHaveBeenCalledWith('uuid-5');
     expect(result).toHaveLength(1);
   });
 
   it('deve usar contexto ativo quando fornecido', async () => {
     mockRepo.findByEntregavelWithContext.mockResolvedValue([{ attachment_id: 2 }]);
-    const result = await service.execute(5, { active_context: { tipo: 'unidade', id: 1 } });
+    const result = await service.execute('uuid-5', { active_context: { tipo: 'unidade', id: 'uuid-1' } });
     expect(mockRepo.findByEntregavelWithContext).toHaveBeenCalled();
     expect(result).toHaveLength(1);
   });
@@ -139,14 +139,14 @@ describe('FindByProcessStepService', () => {
 
   it('deve retornar anexos da etapa de processo', async () => {
     mockRepo.findByEtapaProcesso.mockResolvedValue([{ attachment_id: 2 }]);
-    const result = await service.execute(3);
-    expect(mockRepo.findByEtapaProcesso).toHaveBeenCalledWith(3);
+    const result = await service.execute('uuid-3');
+    expect(mockRepo.findByEtapaProcesso).toHaveBeenCalledWith('uuid-3');
     expect(result).toHaveLength(1);
   });
 
   it('deve usar contexto ativo quando fornecido', async () => {
     mockRepo.findByEtapaProcessoWithContext.mockResolvedValue([{ attachment_id: 3 }]);
-    const result = await service.execute(3, { active_context: { tipo: 'regional', id: 1 } });
+    const result = await service.execute('uuid-3', { active_context: { tipo: 'regional', id: 'uuid-1' } });
     expect(mockRepo.findByEtapaProcessoWithContext).toHaveBeenCalled();
     expect(result).toHaveLength(1);
   });

--- a/PGA-Backend/src/modules/attachment/attachment.spec.ts
+++ b/PGA-Backend/src/modules/attachment/attachment.spec.ts
@@ -68,9 +68,9 @@ describe('FindOneAttachmentService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new FindOneAttachmentService(mockRepo as any); });
 
   it('deve retornar anexo encontrado', async () => {
-    mockRepo.findOneWithContext.mockResolvedValue({ anexo_id: 1 });
+    mockRepo.findOneWithContext.mockResolvedValue({ anexo_id: 'uuid-1' });
     const result = await service.execute('uuid-1');
-    expect(result).toEqual({ anexo_id: 1 });
+    expect(result).toEqual({ anexo_id: 'uuid-1' });
   });
 
   it('deve retornar null se não encontrado', async () => {
@@ -85,7 +85,7 @@ describe('UpdateAttachmentService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new UpdateAttachmentService(mockRepo as any); });
 
   it('deve atualizar o anexo', async () => {
-    mockRepo.update.mockResolvedValue({ anexo_id: 1, item: 'Documento' });
+    mockRepo.update.mockResolvedValue({ anexo_id: 'uuid-1', item: 'Documento' });
     const result = await service.execute('uuid-1', { item: 'Documento' } as any);
     expect((result as any).item).toBe('Documento');
   });

--- a/PGA-Backend/src/modules/audit/audit.spec.ts
+++ b/PGA-Backend/src/modules/audit/audit.spec.ts
@@ -32,12 +32,12 @@ describe('AuditLogService', () => {
 
     const dto = {
       tabela: 'pga',
-      registro_id: 1,
+      registro_id: 'uuid-1',
       ano: 2024,
       operacao: 'CREATE' as any,
       dados_antes: null,
       dados_depois: {},
-      usuario_id: 1,
+      usuario_id: 'uuid-1',
       motivo: 'test',
     };
 
@@ -51,12 +51,12 @@ describe('AuditLogService', () => {
 
     await expect(service.createLog({
       tabela: 'pga',
-      registro_id: 1,
+      registro_id: 'uuid-1',
       ano: 2024,
       operacao: 'CREATE' as any,
       dados_antes: null,
       dados_depois: {},
-      usuario_id: 1,
+      usuario_id: 'uuid-1',
       motivo: '',
     })).rejects.toThrow('DB error');
   });

--- a/PGA-Backend/src/modules/auth/auth.controller.spec.ts
+++ b/PGA-Backend/src/modules/auth/auth.controller.spec.ts
@@ -9,9 +9,15 @@ const mockContextService = {
 
 describe('AuthController', () => {
   let controller: AuthController;
+  let mockRes: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
+    };
     controller = new AuthController(
       mockLoginService as any,
       mockJwtService as any,
@@ -20,15 +26,15 @@ describe('AuthController', () => {
   });
 
   describe('login', () => {
-    it('deve chamar loginService.execute com req.user', async () => {
+    it('deve chamar loginService.execute com req.user e retornar user', async () => {
       const tokenDto = { access_token: 'at', refresh_token: 'rt' };
       mockLoginService.execute.mockResolvedValue(tokenDto);
 
       const req = { user: { email: 'a@a.com', pessoa_id: 1 } };
-      const result = await controller.login(req);
+      const result = await controller.login(req, mockRes);
 
       expect(mockLoginService.execute).toHaveBeenCalledWith(req.user);
-      expect(result).toBe(tokenDto);
+      expect(result).toEqual({ user: req.user });
     });
   });
 
@@ -41,14 +47,15 @@ describe('AuthController', () => {
   });
 
   describe('selectContext', () => {
-    it('deve chamar contextService.selectContext', async () => {
+    it('deve chamar contextService.selectContext e retornar ok', async () => {
       mockContextService.selectContext.mockResolvedValue({ access_token: 'token', refresh_token: 'rt' });
       const result = await controller.selectContext(
         { user: { tipo_usuario: 'Diretor' } },
-        { tipo: 'unidade', id: 1 } as any,
+        { tipo: 'unidade', id: 'uuid-1' } as any,
+        mockRes,
       );
       expect(mockContextService.selectContext).toHaveBeenCalled();
-      expect(result.access_token).toBeDefined();
+      expect((result as any).ok).toBe(true);
     });
   });
 
@@ -61,22 +68,22 @@ describe('AuthController', () => {
   });
 
   describe('refresh', () => {
-    it('deve retornar novo access_token para refresh token válido', () => {
+    it('deve retornar ok para refresh token válido', () => {
       mockJwtService.verify.mockReturnValue({ email: 'a@a.com', pessoa_id: 1 });
       mockJwtService.sign.mockReturnValue('new-access-token');
 
-      const result = controller.refresh('valid-refresh-token');
-      expect(result).toEqual({ access_token: 'new-access-token' });
+      const result = controller.refresh({ cookies: { refresh_token: 'valid-refresh-token' } } as any, mockRes);
+      expect(result).toEqual({ ok: true });
     });
 
     it('deve retornar erro se refresh_token não fornecido', () => {
-      const result = controller.refresh(undefined as any);
+      const result = controller.refresh({ cookies: {} } as any, mockRes);
       expect(result).toHaveProperty('error');
     });
 
     it('deve retornar erro se refresh_token inválido', () => {
       mockJwtService.verify.mockImplementation(() => { throw new Error('invalid'); });
-      const result = controller.refresh('bad-token');
+      const result = controller.refresh({ cookies: { refresh_token: 'bad-token' } } as any, mockRes);
       expect(result).toHaveProperty('error');
     });
   });

--- a/PGA-Backend/src/modules/auth/auth.controller.spec.ts
+++ b/PGA-Backend/src/modules/auth/auth.controller.spec.ts
@@ -30,7 +30,7 @@ describe('AuthController', () => {
       const tokenDto = { access_token: 'at', refresh_token: 'rt' };
       mockLoginService.execute.mockResolvedValue(tokenDto);
 
-      const req = { user: { email: 'a@a.com', pessoa_id: 1 } };
+      const req = { user: { email: 'a@a.com', pessoa_id: 'uuid-1' } };
       const result = await controller.login(req, mockRes);
 
       expect(mockLoginService.execute).toHaveBeenCalledWith(req.user);

--- a/PGA-Backend/src/modules/auth/services/context.service.spec.ts
+++ b/PGA-Backend/src/modules/auth/services/context.service.spec.ts
@@ -67,9 +67,9 @@ describe('ContextService', () => {
       mockPrisma.unidade.findFirst.mockResolvedValue({ unidade_id: 1 });
 
       const result = await service.selectContext(
-        { tipo_usuario: 'Administrador', email: 'a@a.com', pessoa_id: 1, nome: 'A' },
+        { tipo_usuario: 'Administrador', email: 'a@a.com', pessoa_id: 'uuid-1', nome: 'A' },
         'unidade',
-        1,
+        'uuid-1',
       );
 
       expect(result.access_token).toBeDefined();
@@ -79,7 +79,7 @@ describe('ContextService', () => {
       mockPrisma.unidade.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.selectContext({ tipo_usuario: 'Administrador' }, 'unidade', 999),
+        service.selectContext({ tipo_usuario: 'Administrador' }, 'unidade', 'uuid-999'),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -87,7 +87,7 @@ describe('ContextService', () => {
       mockPrisma.pessoa.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.selectContext({ tipo_usuario: 'Administrador' }, 'regional', 999),
+        service.selectContext({ tipo_usuario: 'Administrador' }, 'regional', 'uuid-999'),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -95,7 +95,7 @@ describe('ContextService', () => {
       mockPrisma.pessoaUnidade.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.selectContext({ tipo_usuario: 'Diretor', pessoa_id: 1 }, 'unidade', 5),
+        service.selectContext({ tipo_usuario: 'Diretor', pessoa_id: 'uuid-1' }, 'unidade', 'uuid-5'),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/PGA-Backend/src/modules/course/course.spec.ts
+++ b/PGA-Backend/src/modules/course/course.spec.ts
@@ -30,7 +30,7 @@ describe('CreateCourseService', () => {
   });
 
   it('deve criar e retornar o curso', async () => {
-    const dto = { nome: 'TSI', unidade_id: 1, tipo: 'Superior' as any, status: 'Ativo' as any };
+    const dto = { nome: 'TSI', unidade_id: 'uuid-1', tipo: 'Superior' as any, status: 'Ativo' as any };
     const created = { curso_id: 1, ...dto };
     mockRepo.create.mockResolvedValue(created);
 
@@ -57,15 +57,15 @@ describe('FindAllCourseService', () => {
 
   it('deve filtrar por unidade quando contexto é unidade', async () => {
     mockRepo.findByUnitId.mockResolvedValue([{ curso_id: 2 }]);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 5 } });
-    expect(mockRepo.findByUnitId).toHaveBeenCalledWith(5);
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-5' } });
+    expect(mockRepo.findByUnitId).toHaveBeenCalledWith('uuid-5');
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por regional quando contexto é regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ curso_id: 3 }]);
-    const result = await service.execute({ active_context: { tipo: 'regional', id: 2 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(2);
+    const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-2' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-2');
   });
 });
 
@@ -81,14 +81,14 @@ describe('FindOneCourseService', () => {
     const course = { curso_id: 1, nome: 'TSI' };
     mockRepo.findOneWithContext.mockResolvedValue(course);
 
-    const result = await service.execute(1);
+    const result = await service.execute('uuid-1');
     expect(result).toBe(course);
   });
 
   it('deve lançar NotFoundException se curso não encontrado', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
 
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -105,14 +105,14 @@ describe('UpdateCourseService', () => {
     mockRepo.findOne.mockResolvedValue(course);
     mockRepo.update.mockResolvedValue({ ...course, nome: 'Novo Nome' });
 
-    const result = await service.execute(1, { nome: 'Novo Nome' } as any);
+    const result = await service.execute('uuid-1', { nome: 'Novo Nome' } as any);
     expect(result.nome).toBe('Novo Nome');
   });
 
   it('deve lançar NotFoundException se curso não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
 
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -127,23 +127,23 @@ describe('DeleteCourseService', () => {
   it('deve lançar NotFoundException se curso não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
 
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar ConflictException se há rotinas vinculadas', async () => {
-    mockRepo.findOne.mockResolvedValue({ curso_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ curso_id: 'uuid-1' });
     mockPrisma.rotinaInstitucional.count.mockResolvedValue(2);
 
-    await expect(service.execute(1)).rejects.toThrow();
+    await expect(service.execute('uuid-1')).rejects.toThrow();
   });
 
   it('deve excluir o curso quando sem dependências', async () => {
-    mockRepo.findOne.mockResolvedValue({ curso_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ curso_id: 'uuid-1' });
     mockPrisma.rotinaInstitucional.count.mockResolvedValue(0);
-    mockRepo.softDelete.mockResolvedValue({ curso_id: 1, ativo: false });
+    mockRepo.softDelete.mockResolvedValue({ curso_id: 'uuid-1', ativo: false });
 
-    const result = await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    const result = await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 });
 
@@ -168,7 +168,7 @@ describe('CourseController', () => {
 
   it('create deve chamar createService', async () => {
     mockCreate.execute.mockResolvedValue({ curso_id: 1 });
-    const dto = { nome: 'TSI', unidade_id: 1, tipo: 'Superior' as any, status: 'Ativo' as any };
+    const dto = { nome: 'TSI', unidade_id: 'uuid-1', tipo: 'Superior' as any, status: 'Ativo' as any };
     await controller.create(dto);
     expect(mockCreate.execute).toHaveBeenCalledWith(dto);
   });
@@ -180,20 +180,20 @@ describe('CourseController', () => {
   });
 
   it('findOne deve passar id e user', async () => {
-    mockFindOne.execute.mockResolvedValue({ curso_id: 1 });
-    await controller.findOne({ user: {} }, 1);
-    expect(mockFindOne.execute).toHaveBeenCalledWith(1, {});
+    mockFindOne.execute.mockResolvedValue({ curso_id: 'uuid-1' });
+    await controller.findOne({ user: {} }, 'uuid-1');
+    expect(mockFindOne.execute).toHaveBeenCalledWith('uuid-1', {});
   });
 
   it('update deve passar id e dto', async () => {
-    mockUpdate.execute.mockResolvedValue({ curso_id: 1 });
-    await controller.update(1, {} as any);
-    expect(mockUpdate.execute).toHaveBeenCalledWith(1, {});
+    mockUpdate.execute.mockResolvedValue({ curso_id: 'uuid-1' });
+    await controller.update('uuid-1', {} as any);
+    expect(mockUpdate.execute).toHaveBeenCalledWith('uuid-1', {});
   });
 
   it('delete deve passar id', async () => {
-    mockDelete.execute.mockResolvedValue({ curso_id: 1, ativo: false });
-    await controller.delete(1);
-    expect(mockDelete.execute).toHaveBeenCalledWith(1);
+    mockDelete.execute.mockResolvedValue({ curso_id: 'uuid-1', ativo: false });
+    await controller.delete('uuid-1');
+    expect(mockDelete.execute).toHaveBeenCalledWith('uuid-1');
   });
 });

--- a/PGA-Backend/src/modules/cpaAction/cpa-action.spec.ts
+++ b/PGA-Backend/src/modules/cpaAction/cpa-action.spec.ts
@@ -39,15 +39,15 @@ describe('FindAllCpaActionService', () => {
 
   it('deve filtrar por unidade quando active_context tipo unidade', async () => {
     mockRepo.findAllByUnit.mockResolvedValue([{ cpa_action_id: 2 }]);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 5 } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith(5);
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-5' } });
+    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-5');
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por regional quando active_context tipo regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ cpa_action_id: 3 }]);
-    const result = await service.execute({ active_context: { tipo: 'regional', id: 2 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(2);
+    const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-2' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-2');
     expect(result).toHaveLength(1);
   });
 });
@@ -57,13 +57,13 @@ describe('FindOneCpaActionService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new FindOneCpaActionService(mockRepo as any); });
 
   it('deve retornar ação CPA encontrada', async () => {
-    mockRepo.findOneWithContext.mockResolvedValue({ cpa_action_id: 1 });
-    expect(await service.execute(1)).toEqual({ cpa_action_id: 1 });
+    mockRepo.findOneWithContext.mockResolvedValue({ cpa_action_id: 'uuid-1' });
+    expect(await service.execute('uuid-1')).toEqual({ cpa_action_id: 'uuid-1' });
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -72,15 +72,15 @@ describe('UpdateCpaActionService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new UpdateCpaActionService(mockRepo as any); });
 
   it('deve atualizar e retornar ação CPA', async () => {
-    mockRepo.findOne.mockResolvedValue({ cpa_action_id: 1 });
-    mockRepo.update.mockResolvedValue({ cpa_action_id: 1, descricao: 'Novo' });
-    const result = await service.execute(1, { descricao: 'Novo' } as any);
+    mockRepo.findOne.mockResolvedValue({ cpa_action_id: 'uuid-1' });
+    mockRepo.update.mockResolvedValue({ cpa_action_id: 'uuid-1', descricao: 'Novo' });
+    const result = await service.execute('uuid-1', { descricao: 'Novo' } as any);
     expect(result.descricao).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -89,14 +89,14 @@ describe('DeleteCpaActionService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new DeleteCpaActionService(mockRepo as any); });
 
   it('deve deletar a ação CPA', async () => {
-    mockRepo.findOne.mockResolvedValue({ cpa_action_id: 1 });
-    mockRepo.softDelete.mockResolvedValue({ cpa_action_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    mockRepo.findOne.mockResolvedValue({ cpa_action_id: 'uuid-1' });
+    mockRepo.softDelete.mockResolvedValue({ cpa_action_id: 'uuid-1' });
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/delivers/deliverable.spec.ts
+++ b/PGA-Backend/src/modules/delivers/deliverable.spec.ts
@@ -37,15 +37,15 @@ describe('FindAllDeliverableService', () => {
 
   it('deve filtrar por unidade', async () => {
     mockRepo.findAllByUnit.mockResolvedValue([{ deliverable_id: 2 }]);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 5 } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith(5);
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-5' } });
+    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-5');
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ deliverable_id: 3 }]);
-    const result = await service.execute({ active_context: { tipo: 'regional', id: 2 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(2);
+    const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-2' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-2');
     expect(result).toHaveLength(1);
   });
 });
@@ -55,13 +55,13 @@ describe('FindOneDeliverableService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new FindOneDeliverableService(mockRepo as any); });
 
   it('deve retornar o entregável encontrado', async () => {
-    mockRepo.findOneWithContext.mockResolvedValue({ entregavel_id: 1 });
-    expect(await service.execute(1)).toEqual({ entregavel_id: 1 });
+    mockRepo.findOneWithContext.mockResolvedValue({ entregavel_id: 'uuid-1' });
+    expect(await service.execute('uuid-1')).toEqual({ entregavel_id: 'uuid-1' });
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -72,12 +72,12 @@ describe('UpdateDeliverableService', () => {
   it('deve atualizar e retornar o entregável', async () => {
     mockRepo.findOne.mockResolvedValue({ deliverable_id: 1 });
     mockRepo.update.mockResolvedValue({ entregavel_id: 1, descricao: 'Novo' });
-    expect(((await service.execute(1, { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
+    expect(((await service.execute('uuid-1', { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -88,12 +88,12 @@ describe('DeleteDeliverableService', () => {
   it('deve deletar o entregável', async () => {
     mockRepo.findOne.mockResolvedValue({ deliverable_id: 1 });
     mockRepo.softDelete.mockResolvedValue({ deliverable_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/delivers/deliverable.spec.ts
+++ b/PGA-Backend/src/modules/delivers/deliverable.spec.ts
@@ -35,17 +35,17 @@ describe('FindAllDeliverableService', () => {
     expect(await service.execute()).toHaveLength(1);
   });
 
-  it('deve filtrar por unidade', async () => {
-    mockRepo.findAllByUnit.mockResolvedValue([{ deliverable_id: 2 }]);
+  it('deve retornar todos os entregáveis ignorando contexto de unidade', async () => {
+    mockRepo.findAll.mockResolvedValue([{ deliverable_id: 2 }]);
     const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-5' } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-5');
+    expect(mockRepo.findAll).toHaveBeenCalled();
     expect(result).toHaveLength(1);
   });
 
-  it('deve filtrar por regional', async () => {
-    mockRepo.findAllByRegional.mockResolvedValue([{ deliverable_id: 3 }]);
+  it('deve retornar todos os entregáveis ignorando contexto de regional', async () => {
+    mockRepo.findAll.mockResolvedValue([{ deliverable_id: 3 }]);
     const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-2' } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-2');
+    expect(mockRepo.findAll).toHaveBeenCalled();
     expect(result).toHaveLength(1);
   });
 });

--- a/PGA-Backend/src/modules/delivers/services/find-all-deliverable.service.ts
+++ b/PGA-Backend/src/modules/delivers/services/find-all-deliverable.service.ts
@@ -6,7 +6,7 @@ import { EntregavelLinkSei } from '@prisma/client';
 export class FindAllDeliverableService {
   constructor(private readonly repository: DeliverableRepository) {}
 
-  async execute(user?: any): Promise<EntregavelLinkSei[]> {
+  async execute(_user?: any): Promise<EntregavelLinkSei[]> {
     return this.repository.findAll();
   }
 }

--- a/PGA-Backend/src/modules/institutionalRoutine/institutional-routine.spec.ts
+++ b/PGA-Backend/src/modules/institutionalRoutine/institutional-routine.spec.ts
@@ -39,15 +39,15 @@ describe('FindAllInstitutionalRoutineService', () => {
 
   it('deve filtrar por unidade', async () => {
     mockRepo.findAllByUnit.mockResolvedValue([{ rotina_id: 2 }]);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 5 } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith(5);
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-5' } });
+    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-5');
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ rotina_id: 3 }]);
-    const result = await service.execute({ active_context: { tipo: 'regional', id: 2 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(2);
+    const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-2' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-2');
     expect(result).toHaveLength(1);
   });
 });
@@ -58,12 +58,12 @@ describe('FindOneInstitutionalRoutineService', () => {
 
   it('deve retornar rotina encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue({ rotina_id: 1 });
-    expect(await service.execute(1)).toEqual({ rotina_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ rotina_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -74,12 +74,12 @@ describe('UpdateInstitutionalRoutineService', () => {
   it('deve atualizar e retornar a rotina', async () => {
     mockRepo.findOne.mockResolvedValue({ rotina_id: 1 });
     mockRepo.update.mockResolvedValue({ rotina_id: 1, descricao: 'Novo' });
-    expect(((await service.execute(1, { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
+    expect(((await service.execute('uuid-1', { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -92,12 +92,12 @@ describe('DeleteInstitutionalRoutineService', () => {
     mockPrisma.$transaction.mockImplementation(async (fn: any) =>
       fn({ rotinaOcorrencia: { updateMany: jest.fn() }, rotinaParticipante: { updateMany: jest.fn() }, rotinaInstitucional: { update: jest.fn() } }),
     );
-    await service.execute(1);
+    await service.execute('uuid-1');
     expect(mockPrisma.$transaction).toHaveBeenCalled();
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/pga/pga.repository.ts
+++ b/PGA-Backend/src/modules/pga/pga.repository.ts
@@ -159,9 +159,8 @@ export class PgaRepository extends BaseRepository<PGA> {
   /**
    * Método dedicado para atualizações internas de fluxo (status, pareceres,
    * campos de auditoria) que não fazem parte do UpdatePgaDto público.
-   * Aceita diretamente o tipo Prisma para garantir type-safety sem `as any`.
    */
-  async updateWorkflow(id: string, data: Prisma.PGAUpdateInput) {
+  async updateWorkflow(id: string, data: Prisma.PGAUncheckedUpdateInput) {
     return this.prisma.pGA.update({
       where: { pga_id: id },
       data,

--- a/PGA-Backend/src/modules/pga/pga.spec.ts
+++ b/PGA-Backend/src/modules/pga/pga.spec.ts
@@ -258,7 +258,7 @@ describe('PgaController', () => {
 
   it('create deve chamar createPgaService', async () => {
     mockCreate.execute.mockResolvedValue({ pga_id: 1 });
-    await controller.create({ unidade_id: 1, ano: 2025 } as any, {} as any);
+    await controller.create({ unidade_id: 'uuid-1', ano: 2025 } as any, {} as any);
     expect(mockCreate.execute).toHaveBeenCalled();
   });
 

--- a/PGA-Backend/src/modules/pga/pga.spec.ts
+++ b/PGA-Backend/src/modules/pga/pga.spec.ts
@@ -15,6 +15,7 @@ const mockRepo = {
   findOne: jest.fn(),
   findOneWithContext: jest.fn(),
   update: jest.fn(),
+  updateWorkflow: jest.fn(),
   delete: jest.fn(),
 };
 
@@ -62,21 +63,21 @@ describe('FindAllPgaService', () => {
 
   it('deve retornar todos os PGAs sem contexto', async () => {
     mockRepo.findAll.mockResolvedValue([{ pga_id: 1 }]);
-    const result = await service.execute();
+    const result = await service.execute({ tipo_usuario: 'Administrador' });
     expect(mockRepo.findAll).toHaveBeenCalled();
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por unidade quando contexto é unidade', async () => {
     mockRepo.findAllByUnit.mockResolvedValue([{ pga_id: 2 }]);
-    await service.execute({ active_context: { tipo: 'unidade', id: 3 } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith(3);
+    await service.execute({ tipo_usuario: 'Administrador', active_context: { tipo: 'unidade', id: 'uuid-3' } });
+    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-3', false);
   });
 
   it('deve filtrar por regional quando contexto é regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([]);
-    await service.execute({ active_context: { tipo: 'regional', id: 4 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(4);
+    await service.execute({ active_context: { tipo: 'regional', id: 'uuid-4' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-4');
   });
 });
 
@@ -90,14 +91,14 @@ describe('FindOnePgaService', () => {
   });
 
   it('deve retornar PGA encontrado', async () => {
-    mockRepo.findOneWithContext.mockResolvedValue({ pga_id: 1 });
-    const result = await service.execute(1);
-    expect(result).toEqual({ pga_id: 1 });
+    mockRepo.findOneWithContext.mockResolvedValue({ pga_id: 'uuid-1' });
+    const result = await service.execute('uuid-1');
+    expect(result).toEqual({ pga_id: 'uuid-1' });
   });
 
   it('deve lançar NotFoundException se PGA não encontrado', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -107,27 +108,27 @@ describe('UpdatePgaService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new UpdatePgaService(mockRepo as any);
+    service = new UpdatePgaService(mockRepo as any, mockPrisma as any);
   });
 
   it('deve atualizar PGA', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1, status: 'Rascunho' });
-    mockRepo.update.mockResolvedValue({ pga_id: 1, ano: 2026 });
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1', status: 'Rascunho' });
+    mockRepo.update.mockResolvedValue({ pga_id: 'uuid-1', ano: 2026 });
 
-    const result = await service.execute(1, { ano: 2026 } as any);
+    const result = await service.execute('uuid-1', { ano: 2026 } as any, { tipo_usuario: 'Administrador' });
     expect(result.ano).toBe(2026);
   });
 
   it('deve definir data_elaboracao ao submeter PGA', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1, status: 'Rascunho' });
-    mockRepo.update.mockResolvedValue({ pga_id: 1, status: 'Submetido' });
-    await service.execute(1, { status: 'Submetido' } as any);
-    expect(mockRepo.update).toHaveBeenCalledWith(1, expect.objectContaining({ data_elaboracao: expect.any(Date) }));
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1', status: 'Rascunho' });
+    mockRepo.update.mockResolvedValue({ pga_id: 'uuid-1', status: 'Submetido' });
+    await service.execute('uuid-1', { status: 'Submetido' } as any, { tipo_usuario: 'Administrador' });
+    expect(mockRepo.update).toHaveBeenCalledWith('uuid-1', expect.objectContaining({ data_elaboracao: expect.any(Date) }));
   });
 
   it('deve lançar NotFoundException se PGA não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -142,22 +143,22 @@ describe('DeletePgaService', () => {
 
   it('deve lançar NotFoundException se PGA não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar ConflictException se há ações de projeto ativas', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1' });
     mockPrisma.acaoProjeto.count.mockResolvedValue(3);
 
-    await expect(service.execute(1)).rejects.toThrow(ConflictException);
+    await expect(service.execute('uuid-1')).rejects.toThrow(ConflictException);
   });
 
   it('deve executar transação de delete sem conflitos', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1' });
     mockPrisma.acaoProjeto.count.mockResolvedValue(0);
-    mockPrisma.$transaction.mockResolvedValue({ pga_id: 1, ativo: false });
+    mockPrisma.$transaction.mockResolvedValue({ pga_id: 'uuid-1', ativo: false });
 
-    await service.execute(1);
+    await service.execute('uuid-1');
     expect(mockPrisma.$transaction).toHaveBeenCalled();
   });
 });
@@ -173,53 +174,53 @@ describe('SubmitPgaService', () => {
 
   it('deve lançar NotFoundException se PGA não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, 1)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', 'uuid-1')).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar BadRequestException se PGA não está EmElaboracao', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1, status: 'Submetido' });
-    await expect(service.execute(1, 1)).rejects.toThrow(BadRequestException);
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1', status: 'Submetido' });
+    await expect(service.execute('uuid-1', 'uuid-1')).rejects.toThrow(BadRequestException);
   });
 
   it('deve lançar NotFoundException se pessoa não encontrada', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1, status: 'EmElaboracao' });
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1', status: 'EmElaboracao' });
     mockPrisma.pessoa.findUnique.mockResolvedValue(null);
 
-    await expect(service.execute(1, 99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-1', 'uuid-99')).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar ForbiddenException se Diretor tentar submeter PGA de outra unidade', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1, status: 'EmElaboracao', unidade_id: 10 });
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1', status: 'EmElaboracao', unidade_id: 'uuid-10' });
     mockPrisma.pessoa.findUnique.mockResolvedValue({
       tipo_usuario: 'Diretor',
-      unidades: [{ unidade_id: 20 }],
+      unidades: [{ unidade_id: 'uuid-20' }],
     });
 
-    await expect(service.execute(1, 1)).rejects.toThrow(ForbiddenException);
+    await expect(service.execute('uuid-1', 'uuid-1')).rejects.toThrow(ForbiddenException);
   });
 
   it('deve submeter PGA quando Diretor é da mesma unidade', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1, status: 'EmElaboracao', unidade_id: 10 });
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1', status: 'EmElaboracao', unidade_id: 'uuid-10' });
     mockPrisma.pessoa.findUnique.mockResolvedValue({
       tipo_usuario: 'Diretor',
-      unidades: [{ unidade_id: 10 }],
+      unidades: [{ unidade_id: 'uuid-10' }],
     });
-    mockRepo.update.mockResolvedValue({ pga_id: 1, status: 'Submetido' });
+    mockRepo.updateWorkflow.mockResolvedValue({ pga_id: 'uuid-1', status: 'Submetido' });
 
-    const result = await service.execute(1, 1);
-    expect(mockRepo.update).toHaveBeenCalled();
+    const result = await service.execute('uuid-1', 'uuid-1');
+    expect(mockRepo.updateWorkflow).toHaveBeenCalled();
   });
 
   it('deve submeter PGA para Administrador sem restrição de unidade', async () => {
-    mockRepo.findOne.mockResolvedValue({ pga_id: 1, status: 'EmElaboracao', unidade_id: 10 });
+    mockRepo.findOne.mockResolvedValue({ pga_id: 'uuid-1', status: 'EmElaboracao', unidade_id: 'uuid-10' });
     mockPrisma.pessoa.findUnique.mockResolvedValue({
       tipo_usuario: 'Administrador',
       unidades: [],
     });
-    mockRepo.update.mockResolvedValue({ pga_id: 1, status: 'Submetido' });
+    mockRepo.updateWorkflow.mockResolvedValue({ pga_id: 'uuid-1', status: 'Submetido' });
 
-    await service.execute(1, 1);
-    expect(mockRepo.update).toHaveBeenCalled();
+    await service.execute('uuid-1', 'uuid-1');
+    expect(mockRepo.updateWorkflow).toHaveBeenCalled();
   });
 });
 
@@ -231,6 +232,9 @@ describe('PgaController', () => {
   const mockUpdate = { execute: jest.fn() };
   const mockDelete = { execute: jest.fn() };
   const mockSubmit = { execute: jest.fn() };
+  const mockPublish = { execute: jest.fn() };
+  const mockReviewRegional = { execute: jest.fn() };
+  const mockReviewCps = { execute: jest.fn() };
   const mockExportCsv = { execute: jest.fn() };
   const mockExportPdf = { execute: jest.fn() };
   let controller: PgaController;
@@ -244,6 +248,9 @@ describe('PgaController', () => {
       mockUpdate as any,
       mockDelete as any,
       mockSubmit as any,
+      mockPublish as any,
+      mockReviewRegional as any,
+      mockReviewCps as any,
       mockExportCsv as any,
       mockExportPdf as any,
     );
@@ -251,7 +258,7 @@ describe('PgaController', () => {
 
   it('create deve chamar createPgaService', async () => {
     mockCreate.execute.mockResolvedValue({ pga_id: 1 });
-    await controller.create({ unidade_id: 1, ano: 2025 } as any);
+    await controller.create({ unidade_id: 1, ano: 2025 } as any, {} as any);
     expect(mockCreate.execute).toHaveBeenCalled();
   });
 

--- a/PGA-Backend/src/modules/pga/services/review-pga-cps.service.ts
+++ b/PGA-Backend/src/modules/pga/services/review-pga-cps.service.ts
@@ -23,7 +23,7 @@ export class ReviewPgaCpsService {
     return this.repository.updateWorkflow(pgaId, {
       status: StatusPGA.AprovadoCPS,
       parecer_cps: parecer ?? null,
-      cpsAprovador: { connect: { pessoa_id: pessoaId } },
+      cps_aprovador_id: pessoaId,
       data_parecer_cps: new Date(),
     });
   }
@@ -45,7 +45,7 @@ export class ReviewPgaCpsService {
     return this.repository.updateWorkflow(pgaId, {
       status: StatusPGA.Reprovado,
       parecer_cps: parecer,
-      cpsAprovador: { connect: { pessoa_id: pessoaId } },
+      cps_aprovador_id: pessoaId,
       data_parecer_cps: new Date(),
     });
   }

--- a/PGA-Backend/src/modules/pga/services/review-pga-regional.service.ts
+++ b/PGA-Backend/src/modules/pga/services/review-pga-regional.service.ts
@@ -31,7 +31,7 @@ export class ReviewPgaRegionalService {
       status: StatusPGA.AguardandoCPS,
       parecer_regional: parecer ?? null,
       data_parecer_regional: new Date(),
-      regionalResponsavel: { connect: { pessoa_id: pessoaId } },
+      regional_responsavel_id: pessoaId,
     });
   }
 
@@ -55,7 +55,7 @@ export class ReviewPgaRegionalService {
       status: StatusPGA.Reprovado,
       parecer_regional: parecer,
       data_parecer_regional: new Date(),
-      regionalResponsavel: { connect: { pessoa_id: pessoaId } },
+      regional_responsavel_id: pessoaId,
     });
   }
 

--- a/PGA-Backend/src/modules/priorityAction/priority-action.spec.ts
+++ b/PGA-Backend/src/modules/priorityAction/priority-action.spec.ts
@@ -39,12 +39,12 @@ describe('FindOnePriorityActionService', () => {
 
   it('deve retornar ação prioritária encontrada', async () => {
     mockRepo.findOne.mockResolvedValue({ priority_action_id: 1 });
-    expect(await service.execute(1)).toEqual({ priority_action_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ priority_action_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -55,12 +55,12 @@ describe('UpdatePriorityActionService', () => {
   it('deve atualizar e retornar ação prioritária', async () => {
     mockRepo.findOne.mockResolvedValue({ priority_action_id: 1 });
     mockRepo.update.mockResolvedValue({ priority_action_id: 1, descricao: 'Novo' });
-    expect((await service.execute(1, { descricao: 'Novo' } as any)).descricao).toBe('Novo');
+    expect((await service.execute('uuid-1', { descricao: 'Novo' } as any)).descricao).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -71,12 +71,12 @@ describe('DeletePriorityActionService', () => {
   it('deve deletar a ação prioritária', async () => {
     mockRepo.findOne.mockResolvedValue({ priority_action_id: 1 });
     mockRepo.delete.mockResolvedValue({ priority_action_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.delete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.delete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/problemSituation/problem-situation.spec.ts
+++ b/PGA-Backend/src/modules/problemSituation/problem-situation.spec.ts
@@ -46,12 +46,12 @@ describe('FindOneProblemSituationService', () => {
 
   it('deve retornar situação problema encontrada', async () => {
     mockRepo.findOne.mockResolvedValue({ problem_situation_id: 1 });
-    expect(await service.execute(1)).toEqual({ problem_situation_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ problem_situation_id: 1 });
   });
 
   it('deve retornar null se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    expect(await service.execute(99)).toBeNull();
+    expect(await service.execute('uuid-99')).toBeNull();
   });
 });
 
@@ -63,18 +63,18 @@ describe('UpdateProblemSituationService', () => {
     mockRepo.findOne.mockResolvedValue({ problem_situation_id: 1, situacao_id: 1 });
     mockRepo.findByCodigoCategoria.mockResolvedValue(null);
     mockRepo.update.mockResolvedValue({ problem_situation_id: 1, descricao: 'Novo' });
-    expect((await service.execute(1, { descricao: 'Novo' } as any)).descricao).toBe('Novo');
+    expect((await service.execute('uuid-1', { descricao: 'Novo' } as any)).descricao).toBe('Novo');
   });
 
   it('deve lançar ConflictException se código em uso por outra situação ativa', async () => {
     mockRepo.findOne.mockResolvedValue({ situacao_id: 1 });
     mockRepo.findByCodigoCategoria.mockResolvedValue({ situacao_id: 99, ativo: true });
-    await expect(service.execute(1, { codigo_categoria: 'X1' } as any)).rejects.toThrow(ConflictException);
+    await expect(service.execute('uuid-1', { codigo_categoria: 'X1' } as any)).rejects.toThrow(ConflictException);
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -85,12 +85,12 @@ describe('DeleteProblemSituationService', () => {
   it('deve deletar a situação problema', async () => {
     mockRepo.findOne.mockResolvedValue({ problem_situation_id: 1 });
     mockRepo.softDelete.mockResolvedValue({ problem_situation_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/processStep/process-step.spec.ts
+++ b/PGA-Backend/src/modules/processStep/process-step.spec.ts
@@ -56,12 +56,12 @@ describe('FindOneProcessStepService', () => {
 
   it('deve retornar a etapa encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue({ etapa_id: 1 });
-    expect(await service.execute(1)).toEqual({ etapa_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ etapa_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -72,12 +72,12 @@ describe('UpdateProcessStepService', () => {
   it('deve atualizar e retornar a etapa', async () => {
     mockRepo.findOne.mockResolvedValue({ process_step_id: 1 });
     mockRepo.update.mockResolvedValue({ etapa_id: 1, descricao: 'Novo' });
-    expect(((await service.execute(1, { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
+    expect((await service.execute('uuid-1', { descricao: 'Novo' } as any)).descricao).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -88,12 +88,12 @@ describe('DeleteProcessStepService', () => {
   it('deve deletar a etapa de processo', async () => {
     mockRepo.findOne.mockResolvedValue({ process_step_id: 1 });
     mockRepo.softDelete.mockResolvedValue({ process_step_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/project1/project1.spec.ts
+++ b/PGA-Backend/src/modules/project1/project1.spec.ts
@@ -63,15 +63,15 @@ describe('FindAllProject1Service', () => {
 
   it('deve filtrar por unidade', async () => {
     mockRepo.findAllByUnit.mockResolvedValue([{ acao_projeto_id: 2 }]);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 3 } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith(3);
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-3' } });
+    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-3');
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ acao_projeto_id: 3 }]);
-    const result = await service.execute({ active_context: { tipo: 'regional', id: 1 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(1);
+    const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-1' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-1');
     expect(result).toHaveLength(1);
   });
 });
@@ -82,12 +82,12 @@ describe('FindOneProject1Service', () => {
 
   it('deve retornar o projeto encontrado', async () => {
     mockRepo.findOneWithContext.mockResolvedValue({ acao_projeto_id: 1 });
-    expect(await service.execute(1)).toEqual({ acao_projeto_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ acao_projeto_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -98,61 +98,61 @@ describe('UpdateProject1Service', () => {
   it('deve atualizar e retornar o projeto', async () => {
     mockRepo.update.mockResolvedValue(undefined);
     mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1, titulo: 'Novo' });
-    const result = await service.execute(1, { titulo: 'Novo' } as any);
+    const result = await service.execute('uuid-1', { titulo: 'Novo' } as any);
     expect((result as any).titulo).toBe('Novo');
     expect(mockRepo.update).toHaveBeenCalled();
   });
 
   it('deve atualizar situacoes_problema_ids vazias (só deleteMany)', async () => {
-    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 'uuid-1' });
     mockPrisma.acaoProjetoSituacaoProblema.deleteMany.mockResolvedValue({});
-    await service.execute(1, { situacoes_problema_ids: [] } as any);
+    await service.execute('uuid-1', { situacoes_problema_ids: [] } as any);
     expect(mockPrisma.acaoProjetoSituacaoProblema.deleteMany).toHaveBeenCalled();
     expect(mockPrisma.acaoProjetoSituacaoProblema.createMany).not.toHaveBeenCalled();
   });
 
   it('deve atualizar situacoes_problema_ids com valores válidos (deleteMany + createMany)', async () => {
-    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 'uuid-1' });
     mockPrisma.acaoProjetoSituacaoProblema.deleteMany.mockResolvedValue({});
     mockPrisma.acaoProjetoSituacaoProblema.createMany.mockResolvedValue({});
-    await service.execute(1, { situacoes_problema_ids: [1, 2] } as any);
+    await service.execute('uuid-1', { situacoes_problema_ids: [1, 2] } as any);
     expect(mockPrisma.acaoProjetoSituacaoProblema.deleteMany).toHaveBeenCalled();
     expect(mockPrisma.acaoProjetoSituacaoProblema.createMany).toHaveBeenCalled();
   });
 
   it('deve criar novas pessoas (sem projeto_pessoa_id)', async () => {
-    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 'uuid-1' });
     mockPrisma.projetoPessoa.deleteMany.mockResolvedValue({});
     mockPrisma.projetoPessoa.create.mockResolvedValue({});
     const pessoas = [{ pessoa_id: 10, papel: 'Colaborador' }];
-    await service.execute(1, { pessoas } as any);
+    await service.execute('uuid-1', { pessoas } as any);
     expect(mockPrisma.projetoPessoa.create).toHaveBeenCalled();
   });
 
   it('deve atualizar pessoas existentes (com projeto_pessoa_id)', async () => {
-    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 'uuid-1' });
     mockPrisma.projetoPessoa.deleteMany.mockResolvedValue({});
     mockPrisma.projetoPessoa.update.mockResolvedValue({});
     const pessoas = [{ pessoa_id: 10, projeto_pessoa_id: 5, papel: 'Líder' }];
-    await service.execute(1, { pessoas } as any);
+    await service.execute('uuid-1', { pessoas } as any);
     expect(mockPrisma.projetoPessoa.update).toHaveBeenCalled();
   });
 
   it('deve criar novas etapas (sem etapa_id)', async () => {
-    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 'uuid-1' });
     mockPrisma.etapaProcesso.deleteMany.mockResolvedValue({});
     mockPrisma.etapaProcesso.create.mockResolvedValue({});
     const etapas = [{ descricao: 'Etapa nova' }];
-    await service.execute(1, { etapas } as any);
+    await service.execute('uuid-1', { etapas } as any);
     expect(mockPrisma.etapaProcesso.create).toHaveBeenCalled();
   });
 
   it('deve atualizar etapas existentes (com etapa_id)', async () => {
-    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 'uuid-1' });
     mockPrisma.etapaProcesso.deleteMany.mockResolvedValue({});
     mockPrisma.etapaProcesso.update.mockResolvedValue({});
     const etapas = [{ etapa_id: 7, descricao: 'Etapa existente' }];
-    await service.execute(1, { etapas } as any);
+    await service.execute('uuid-1', { etapas } as any);
     expect(mockPrisma.etapaProcesso.update).toHaveBeenCalled();
   });
 });
@@ -166,15 +166,15 @@ describe('DeleteProject1Service', () => {
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 
   it('deve executar $transaction para excluir o projeto e dependências', async () => {
-    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ acao_projeto_id: 'uuid-1' });
     mockPrisma.$transaction.mockImplementation(async (fn: any) =>
       fn({ etapaProcesso: { updateMany: jest.fn() }, projetoPessoa: { updateMany: jest.fn() }, anexo: { updateMany: jest.fn() }, acaoProjetoSituacaoProblema: { updateMany: jest.fn() } }),
     );
-    await service.execute(1);
+    await service.execute('uuid-1');
     expect(mockPrisma.$transaction).toHaveBeenCalled();
   });
 });

--- a/PGA-Backend/src/modules/projectPerson/project-person.spec.ts
+++ b/PGA-Backend/src/modules/projectPerson/project-person.spec.ts
@@ -37,15 +37,15 @@ describe('FindAllProjectPersonService', () => {
 
   it('deve filtrar por unidade', async () => {
     mockRepo.findAllByUnit.mockResolvedValue([{ projeto_pessoa_id: 2 }]);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 3 } });
-    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith(3);
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-3' } });
+    expect(mockRepo.findAllByUnit).toHaveBeenCalledWith('uuid-3');
     expect(result).toHaveLength(1);
   });
 
   it('deve filtrar por regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ projeto_pessoa_id: 3 }]);
-    const result = await service.execute({ active_context: { tipo: 'regional', id: 1 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(1);
+    const result = await service.execute({ active_context: { tipo: 'regional', id: 'uuid-1' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-1');
     expect(result).toHaveLength(1);
   });
 });
@@ -56,12 +56,12 @@ describe('FindOneProjectPersonService', () => {
 
   it('deve retornar a associação encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue({ projeto_pessoa_id: 1 });
-    expect(await service.execute(1)).toEqual({ projeto_pessoa_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ projeto_pessoa_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -72,12 +72,12 @@ describe('UpdateProjectPersonService', () => {
   it('deve atualizar e retornar a associação', async () => {
     mockRepo.findOne.mockResolvedValue({ projeto_pessoa_id: 1 });
     mockRepo.update.mockResolvedValue({ projeto_pessoa_id: 1, papel: 'Coordenador' });
-    expect((await service.execute(1, { papel: 'Coordenador' } as any)).papel).toBe('Coordenador');
+    expect((await service.execute('uuid-1', { papel: 'Coordenador' } as any)).papel).toBe('Coordenador');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -88,12 +88,12 @@ describe('DeleteProjectPersonService', () => {
   it('deve deletar a associação', async () => {
     mockRepo.findOne.mockResolvedValue({ projeto_pessoa_id: 1 });
     mockRepo.delete.mockResolvedValue({ projeto_pessoa_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.delete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.delete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/regional/regional.repository.ts
+++ b/PGA-Backend/src/modules/regional/regional.repository.ts
@@ -190,11 +190,11 @@ export class RegionalRepository {
     };
 
     if (filters.unidadeId) {
-      const existingPga = (where.pga ?? {}) as Prisma.AcaoProjetoWhereInput;
+      const existingPga = (where.pga ?? {}) as Prisma.PGAWhereInput;
       where.pga = {
         ...existingPga,
         unidade_id: { equals: filters.unidadeId },
-      };
+      } as Prisma.PGAWhereInput;
     }
 
     if (filters.pgaId) {

--- a/PGA-Backend/src/modules/regional/regional.spec.ts
+++ b/PGA-Backend/src/modules/regional/regional.spec.ts
@@ -68,13 +68,13 @@ describe('GetRegionalService', () => {
 
   it('deve retornar regional encontrada', async () => {
     mockRepo.findById.mockResolvedValue({ regional_id: 1 });
-    const result = await service.execute(1);
+    const result = await service.execute('uuid-1');
     expect(result).toEqual({ regional_id: 1 });
   });
 
   it('deve lançar NotFoundException se regional não encontrada', async () => {
     mockRepo.findById.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -88,14 +88,14 @@ describe('ReviewRegionalPgaService', () => {
 
   it('deve lançar BadRequestException para status inválido', async () => {
     await expect(
-      service.execute(1, 1, { status: 'EmElaboracao' as any, parecer: '' }),
+      service.execute('uuid-1', 'uuid-1', { status: 'EmElaboracao' as any, parecer: '' }),
     ).rejects.toThrow(BadRequestException);
   });
 
   it('deve lançar NotFoundException se PGA não encontrado para a regional', async () => {
     mockRepo.findPgaForRegional.mockResolvedValue(null);
     await expect(
-      service.execute(1, 99, { status: 'Aprovado' as any, parecer: '' }),
+      service.execute('uuid-1', 'uuid-99', { status: 'Aprovado' as any, parecer: '' }),
     ).rejects.toThrow(NotFoundException);
   });
 
@@ -103,7 +103,7 @@ describe('ReviewRegionalPgaService', () => {
     mockRepo.findPgaForRegional.mockResolvedValue({ pga_id: 1 });
     mockRepo.updatePgaReview.mockResolvedValue({ pga_id: 1, status: 'Aprovado' });
 
-    const result = await service.execute(1, 1, { status: 'Aprovado' as any, parecer: 'OK' });
+    const result = await service.execute('uuid-1', 'uuid-1', { status: 'Aprovado' as any, parecer: 'OK' });
     expect(mockRepo.updatePgaReview).toHaveBeenCalled();
     expect(result.status).toBe('Aprovado');
   });
@@ -112,7 +112,7 @@ describe('ReviewRegionalPgaService', () => {
     mockRepo.findPgaForRegional.mockResolvedValue({ pga_id: 1 });
     mockRepo.updatePgaReview.mockResolvedValue({ pga_id: 1, status: 'Reprovado' });
 
-    const result = await service.execute(1, 1, { status: 'Reprovado' as any, parecer: 'Não aprovado' });
+    const result = await service.execute('uuid-1', 'uuid-1', { status: 'Reprovado' as any, parecer: 'Não aprovado' });
     expect(result.status).toBe('Reprovado');
   });
 });
@@ -123,8 +123,8 @@ describe('FindRegionalByResponsavelService', () => {
 
   it('deve retornar regionais por responsável', async () => {
     mockRepo.findRegionalByResponsavelId.mockResolvedValue([{ regional_id: 1 }]);
-    const result = await service.execute(10);
-    expect(mockRepo.findRegionalByResponsavelId).toHaveBeenCalledWith(10);
+    const result = await service.execute('uuid-10');
+    expect(mockRepo.findRegionalByResponsavelId).toHaveBeenCalledWith('uuid-10');
     expect(result).toHaveLength(1);
   });
 });
@@ -135,13 +135,13 @@ describe('GetRegionalPgaService', () => {
 
   it('deve retornar PGA da regional', async () => {
     mockRepo.findPgaForRegional.mockResolvedValue({ pga_id: 5 });
-    const result = await service.execute(1, 5);
+    const result = await service.execute('uuid-1', 'uuid-5');
     expect(result).toEqual({ pga_id: 5 });
   });
 
   it('deve lançar NotFoundException se PGA não encontrado', async () => {
     mockRepo.findPgaForRegional.mockResolvedValue(null);
-    await expect(service.execute(1, 99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-1', 'uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -151,13 +151,13 @@ describe('GetRegionalProjectService', () => {
 
   it('deve retornar projeto da regional', async () => {
     mockRepo.findProjectForRegional.mockResolvedValue({ acao_projeto_id: 3 });
-    const result = await service.execute(1, 3);
+    const result = await service.execute('uuid-1', 'uuid-3');
     expect(result).toEqual({ acao_projeto_id: 3 });
   });
 
   it('deve lançar NotFoundException se projeto não encontrado', async () => {
     mockRepo.findProjectForRegional.mockResolvedValue(null);
-    await expect(service.execute(1, 99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-1', 'uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -167,8 +167,8 @@ describe('ListRegionalPgasService', () => {
 
   it('deve retornar PGAs da regional com filtros', async () => {
     mockRepo.findPgasByRegional.mockResolvedValue([{ pga_id: 1 }]);
-    const result = await service.execute(1, {} as any);
-    expect(mockRepo.findPgasByRegional).toHaveBeenCalledWith(1, {});
+    const result = await service.execute('uuid-1', {} as any);
+    expect(mockRepo.findPgasByRegional).toHaveBeenCalledWith('uuid-1', {});
     expect(result).toHaveLength(1);
   });
 });
@@ -179,8 +179,8 @@ describe('ListRegionalProjectsService', () => {
 
   it('deve retornar projetos da regional com filtros', async () => {
     mockRepo.findProjectsByRegional.mockResolvedValue([{ acao_projeto_id: 1 }]);
-    const result = await service.execute(1, {} as any);
-    expect(mockRepo.findProjectsByRegional).toHaveBeenCalledWith(1, {});
+    const result = await service.execute('uuid-1', {} as any);
+    expect(mockRepo.findProjectsByRegional).toHaveBeenCalledWith('uuid-1', {});
     expect(result).toHaveLength(1);
   });
 });
@@ -191,8 +191,8 @@ describe('ListRegionalUnitsService', () => {
 
   it('deve retornar unidades da regional', async () => {
     mockRepo.findUnitsByRegional.mockResolvedValue([{ unidade_id: 1 }]);
-    const result = await service.execute(1);
-    expect(mockRepo.findUnitsByRegional).toHaveBeenCalledWith(1);
+    const result = await service.execute('uuid-1');
+    expect(mockRepo.findUnitsByRegional).toHaveBeenCalledWith('uuid-1');
     expect(result).toHaveLength(1);
   });
 });
@@ -203,21 +203,21 @@ describe('ReviewRegionalProjectService', () => {
 
   it('deve lançar BadRequestException para status inválido', async () => {
     await expect(
-      service.execute(1, 1, { status: 'EmElaboracao' as any, parecer: '' }),
+      service.execute('uuid-1', 'uuid-1', { status: 'EmElaboracao' as any, parecer: '' }),
     ).rejects.toThrow(BadRequestException);
   });
 
   it('deve lançar NotFoundException se projeto não encontrado', async () => {
     mockRepo.findProjectForRegional.mockResolvedValue(null);
     await expect(
-      service.execute(1, 99, { status: 'Aprovado' as any, parecer: '' }),
+      service.execute('uuid-1', 'uuid-99', { status: 'Aprovado' as any, parecer: '' }),
     ).rejects.toThrow(NotFoundException);
   });
 
   it('deve aprovar projeto', async () => {
     mockRepo.findProjectForRegional.mockResolvedValue({ acao_projeto_id: 1 });
     mockRepo.updateProjectReview.mockResolvedValue({ acao_projeto_id: 1, status: 'Aprovado' });
-    const result = await service.execute(1, 1, { status: 'Aprovado' as any, parecer: 'OK' });
+    const result = await service.execute('uuid-1', 'uuid-1', { status: 'Aprovado' as any, parecer: 'OK' });
     expect(mockRepo.updateProjectReview).toHaveBeenCalled();
     expect((result as any).status).toBe('Aprovado');
   });
@@ -225,7 +225,7 @@ describe('ReviewRegionalProjectService', () => {
   it('deve reprovar projeto', async () => {
     mockRepo.findProjectForRegional.mockResolvedValue({ acao_projeto_id: 1 });
     mockRepo.updateProjectReview.mockResolvedValue({ acao_projeto_id: 1, status: 'Reprovado' });
-    const result = await service.execute(1, 1, { status: 'Reprovado' as any, parecer: 'Não aprovado' });
+    const result = await service.execute('uuid-1', 'uuid-1', { status: 'Reprovado' as any, parecer: 'Não aprovado' });
     expect((result as any).status).toBe('Reprovado');
   });
 });

--- a/PGA-Backend/src/modules/routineOccurrence/routine-occurrence.spec.ts
+++ b/PGA-Backend/src/modules/routineOccurrence/routine-occurrence.spec.ts
@@ -39,12 +39,12 @@ describe('FindOneRoutineOccurrenceService', () => {
 
   it('deve retornar a ocorrência encontrada', async () => {
     mockRepo.findOne.mockResolvedValue({ occurrence_id: 1 });
-    expect(await service.execute(1)).toEqual({ occurrence_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ occurrence_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -55,12 +55,12 @@ describe('UpdateRoutineOccurrenceService', () => {
   it('deve atualizar e retornar a ocorrência', async () => {
     mockRepo.findOne.mockResolvedValue({ occurrence_id: 1 });
     mockRepo.update.mockResolvedValue({ occurrence_id: 1, status: 'Concluída' });
-    expect((await service.execute(1, { status: 'Concluída' } as any)).status).toBe('Concluída');
+    expect((await service.execute('uuid-1', { status: 'Concluída' } as any)).status).toBe('Concluída');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -71,12 +71,12 @@ describe('DeleteRoutineOccurrenceService', () => {
   it('deve deletar a ocorrência', async () => {
     mockRepo.findOne.mockResolvedValue({ occurrence_id: 1 });
     mockRepo.softDelete.mockResolvedValue({ occurrence_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/routineParticipant/routine-participant.spec.ts
+++ b/PGA-Backend/src/modules/routineParticipant/routine-participant.spec.ts
@@ -39,12 +39,12 @@ describe('FindOneRoutineParticipantService', () => {
 
   it('deve retornar o participante encontrado', async () => {
     mockRepo.findOne.mockResolvedValue({ participant_id: 1 });
-    expect(await service.execute(1)).toEqual({ participant_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ participant_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -55,12 +55,12 @@ describe('UpdateRoutineParticipantService', () => {
   it('deve atualizar e retornar o participante', async () => {
     mockRepo.findOne.mockResolvedValue({ participant_id: 1 });
     mockRepo.update.mockResolvedValue({ rotina_participante_id: 1, papel: 'Coordenador' });
-    expect(((await service.execute(1, { papel: 'Coordenador' } as any)) as any).papel).toBe('Coordenador');
+    expect(((await service.execute('uuid-1', { papel: 'Coordenador' } as any)) as any).papel).toBe('Coordenador');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -71,12 +71,12 @@ describe('DeleteRoutineParticipantService', () => {
   it('deve deletar o participante', async () => {
     mockRepo.findOne.mockResolvedValue({ participant_id: 1 });
     mockRepo.softDelete.mockResolvedValue({ participant_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/thematicAxis/thematic-axis.spec.ts
+++ b/PGA-Backend/src/modules/thematicAxis/thematic-axis.spec.ts
@@ -18,8 +18,8 @@ describe('CreateThematicAxisService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new CreateThematicAxisService(mockRepo as any); });
 
   it('deve criar e retornar o eixo temático', async () => {
-    mockRepo.create.mockResolvedValue({ thematic_axis_id: 1 });
-    expect(await service.execute({ nome: 'Eixo 1' } as any)).toEqual({ thematic_axis_id: 1 });
+    mockRepo.create.mockResolvedValue({ eixo_id: 'uuid-1' });
+    expect(await service.execute({ nome_eixo: 'Eixo 1' } as any)).toEqual({ eixo_id: 'uuid-1' });
   });
 });
 
@@ -28,7 +28,7 @@ describe('FindAllThematicAxisService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new FindAllThematicAxisService(mockRepo as any); });
 
   it('deve retornar todos os eixos temáticos', async () => {
-    mockRepo.findAll.mockResolvedValue([{ thematic_axis_id: 1 }]);
+    mockRepo.findAll.mockResolvedValue([{ eixo_id: 'uuid-1' }]);
     expect(await service.execute()).toHaveLength(1);
   });
 });
@@ -38,8 +38,8 @@ describe('FindOneThematicAxisService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new FindOneThematicAxisService(mockRepo as any); });
 
   it('deve retornar o eixo encontrado', async () => {
-    mockRepo.findOne.mockResolvedValue({ eixo_id: 1 });
-    expect(await service.execute('uuid-1')).toEqual({ eixo_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ eixo_id: 'uuid-1' });
+    expect(await service.execute('uuid-1')).toEqual({ eixo_id: 'uuid-1' });
   });
 
   it('deve retornar null se não encontrado', async () => {
@@ -53,7 +53,7 @@ describe('UpdateThematicAxisService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new UpdateThematicAxisService(mockRepo as any); });
 
   it('deve atualizar e retornar o eixo', async () => {
-    mockRepo.findOne.mockResolvedValue({ thematic_axis_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ eixo_id: 'uuid-1' });
     mockRepo.update.mockResolvedValue({ eixo_id: 'uuid-1', nome_eixo: 'Novo' });
     expect((await service.execute('uuid-1', { nome_eixo: 'Novo' } as any) as any).nome_eixo).toBe('Novo');
   });
@@ -69,8 +69,8 @@ describe('DeleteThematicAxisService', () => {
   beforeEach(() => { jest.clearAllMocks(); service = new DeleteThematicAxisService(mockRepo as any); });
 
   it('deve deletar o eixo temático', async () => {
-    mockRepo.findOne.mockResolvedValue({ thematic_axis_id: 1 });
-    mockRepo.softDelete.mockResolvedValue({ thematic_axis_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ eixo_id: 'uuid-1' });
+    mockRepo.softDelete.mockResolvedValue({ eixo_id: 'uuid-1' });
     await service.execute('uuid-1');
     expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });

--- a/PGA-Backend/src/modules/thematicAxis/thematic-axis.spec.ts
+++ b/PGA-Backend/src/modules/thematicAxis/thematic-axis.spec.ts
@@ -39,12 +39,12 @@ describe('FindOneThematicAxisService', () => {
 
   it('deve retornar o eixo encontrado', async () => {
     mockRepo.findOne.mockResolvedValue({ eixo_id: 1 });
-    expect(await service.execute(1)).toEqual({ eixo_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ eixo_id: 1 });
   });
 
   it('deve retornar null se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    expect(await service.execute(99)).toBeNull();
+    expect(await service.execute('uuid-99')).toBeNull();
   });
 });
 
@@ -54,13 +54,13 @@ describe('UpdateThematicAxisService', () => {
 
   it('deve atualizar e retornar o eixo', async () => {
     mockRepo.findOne.mockResolvedValue({ thematic_axis_id: 1 });
-    mockRepo.update.mockResolvedValue({ eixo_id: 1, nome: 'Novo' });
-    expect(((await service.execute(1, { nome: 'Novo' } as any)) as any).nome).toBe('Novo');
+    mockRepo.update.mockResolvedValue({ eixo_id: 'uuid-1', nome_eixo: 'Novo' });
+    expect((await service.execute('uuid-1', { nome_eixo: 'Novo' } as any) as any).nome_eixo).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -71,12 +71,12 @@ describe('DeleteThematicAxisService', () => {
   it('deve deletar o eixo temático', async () => {
     mockRepo.findOne.mockResolvedValue({ thematic_axis_id: 1 });
     mockRepo.softDelete.mockResolvedValue({ thematic_axis_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/themes/theme.spec.ts
+++ b/PGA-Backend/src/modules/themes/theme.spec.ts
@@ -40,12 +40,12 @@ describe('FindOneThemeService', () => {
 
   it('deve retornar o tema encontrado', async () => {
     mockRepo.findOne.mockResolvedValue({ tema_id: 1 });
-    expect(await service.execute(1)).toEqual({ tema_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ tema_id: 1 });
   });
 
   it('deve retornar null se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    expect(await service.execute(99)).toBeNull();
+    expect(await service.execute('uuid-99')).toBeNull();
   });
 });
 
@@ -56,12 +56,12 @@ describe('UpdateThemeService', () => {
   it('deve atualizar e retornar o tema', async () => {
     mockRepo.findOne.mockResolvedValue({ theme_id: 1 });
     mockRepo.update.mockResolvedValue({ tema_id: 1, descricao: 'Novo' });
-    expect(((await service.execute(1, { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
+    expect((await service.execute('uuid-1', { descricao: 'Novo' } as any) as any).descricao).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -72,12 +72,12 @@ describe('DeleteThemeService', () => {
   it('deve deletar o tema', async () => {
     mockRepo.findOne.mockResolvedValue({ tema_id: 1 });
     mockRepo.delete.mockResolvedValue({ tema_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.delete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.delete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/unit/unit.spec.ts
+++ b/PGA-Backend/src/modules/unit/unit.spec.ts
@@ -58,21 +58,21 @@ describe('FindAllUnitsService', () => {
   });
 
   it('deve retornar unidade específica no contexto de unidade', async () => {
-    mockRepo.findOne.mockResolvedValue({ unidade_id: 5 });
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 5 } });
-    expect(result).toEqual([{ unidade_id: 5 }]);
+    mockRepo.findOne.mockResolvedValue({ unidade_id: 'uuid-5' });
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-5' } });
+    expect(result).toEqual([{ unidade_id: 'uuid-5' }]);
   });
 
   it('deve retornar array vazio se unidade do contexto não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    const result = await service.execute({ active_context: { tipo: 'unidade', id: 99 } });
+    const result = await service.execute({ active_context: { tipo: 'unidade', id: 'uuid-99' } });
     expect(result).toEqual([]);
   });
 
   it('deve filtrar por regional quando contexto é regional', async () => {
     mockRepo.findAllByRegional.mockResolvedValue([{ unidade_id: 2 }]);
-    await service.execute({ active_context: { tipo: 'regional', id: 3 } });
-    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith(3);
+    await service.execute({ active_context: { tipo: 'regional', id: 'uuid-3' } });
+    expect(mockRepo.findAllByRegional).toHaveBeenCalledWith('uuid-3');
   });
 });
 
@@ -86,13 +86,13 @@ describe('FindOneUnitService', () => {
 
   it('deve retornar unidade encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue({ unidade_id: 1 });
-    const result = await service.execute(1);
+    const result = await service.execute('uuid-1');
     expect(result).toEqual({ unidade_id: 1 });
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOneWithContext.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -108,13 +108,13 @@ describe('UpdateUnitService', () => {
     mockRepo.findOne.mockResolvedValue({ unidade_id: 1 });
     mockRepo.update.mockResolvedValue({ unidade_id: 1, nome_unidade: 'Novo' });
 
-    const result = await service.execute(1, { nome_unidade: 'Novo' } as any);
+    const result = await service.execute('uuid-1', { nome_unidade: 'Novo' } as any);
     expect(result.nome_unidade).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -128,22 +128,22 @@ describe('DeleteUnitService', () => {
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar ConflictException se há PGAs ativos', async () => {
-    mockRepo.findOne.mockResolvedValue({ unidade_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ unidade_id: 'uuid-1' });
     mockPrisma.pGA.count.mockResolvedValue(1);
-    await expect(service.execute(1)).rejects.toThrow(ConflictException);
+    await expect(service.execute('uuid-1')).rejects.toThrow(ConflictException);
   });
 
   it('deve excluir quando sem dependências', async () => {
-    mockRepo.findOne.mockResolvedValue({ unidade_id: 1 });
+    mockRepo.findOne.mockResolvedValue({ unidade_id: 'uuid-1' });
     mockPrisma.pGA.count.mockResolvedValue(0);
-    mockRepo.softDelete.mockResolvedValue({ unidade_id: 1, ativo: false });
+    mockRepo.softDelete.mockResolvedValue({ unidade_id: 'uuid-1', ativo: false });
 
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 });
 

--- a/PGA-Backend/src/modules/user/services/change-user-role.service.spec.ts
+++ b/PGA-Backend/src/modules/user/services/change-user-role.service.spec.ts
@@ -23,47 +23,47 @@ describe('ChangeUserRoleService', () => {
 
   it('deve lançar NotFoundException se usuário alvo não encontrado', async () => {
     mockRepo.findById.mockResolvedValue(null);
-    await expect(service.execute(99, 'Diretor' as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', 'Diretor' as any)).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar ForbiddenException se usuário logado sem permissão', async () => {
     mockRepo.findById
-      .mockResolvedValueOnce({ pessoa_id: 1, tipo_usuario: 'Docente' })
-      .mockResolvedValueOnce({ pessoa_id: 2, tipo_usuario: 'Docente' });
-    await expect(service.execute(1, 'Diretor' as any, undefined, 2)).rejects.toThrow(ForbiddenException);
+      .mockResolvedValueOnce({ pessoa_id: 'uuid-1', tipo_usuario: 'Docente' })
+      .mockResolvedValueOnce({ pessoa_id: 'uuid-2', tipo_usuario: 'Docente' });
+    await expect(service.execute('uuid-1', 'Diretor' as any, undefined, 'uuid-2')).rejects.toThrow(ForbiddenException);
   });
 
   it('deve executar transação se usuário logado é Administrador', async () => {
     mockRepo.findById
-      .mockResolvedValueOnce({ pessoa_id: 1, tipo_usuario: 'Docente' })
-      .mockResolvedValueOnce({ pessoa_id: 2, tipo_usuario: 'Administrador' });
-    mockTx.unidade.findUnique.mockResolvedValue({ unidade_id: 10, diretor_id: null });
-    await service.execute(1, 'Diretor' as any, 10, 2);
+      .mockResolvedValueOnce({ pessoa_id: 'uuid-1', tipo_usuario: 'Docente' })
+      .mockResolvedValueOnce({ pessoa_id: 'uuid-2', tipo_usuario: 'Administrador' });
+    mockTx.unidade.findUnique.mockResolvedValue({ unidade_id: 'uuid-10', diretor_id: null });
+    await service.execute('uuid-1', 'Diretor' as any, 'uuid-10', 'uuid-2');
     expect(mockPrisma.$transaction).toHaveBeenCalled();
   });
 
   it('deve remover vínculo diretor quando mudando de Diretor para outro tipo', async () => {
-    mockRepo.findById.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Diretor' });
-    mockTx.unidade.findFirst.mockResolvedValue({ unidade_id: 5 });
+    mockRepo.findById.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Diretor' });
+    mockTx.unidade.findFirst.mockResolvedValue({ unidade_id: 'uuid-5' });
     mockTx.unidade.update.mockResolvedValue({});
-    await service.execute(1, 'Docente' as any);
+    await service.execute('uuid-1', 'Docente' as any);
     expect(mockTx.unidade.update).toHaveBeenCalled();
   });
 
   it('deve lançar ForbiddenException se definindo Diretor sem unidadeId', async () => {
-    mockRepo.findById.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Docente' });
-    await expect(service.execute(1, 'Diretor' as any)).rejects.toThrow(ForbiddenException);
+    mockRepo.findById.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Docente' });
+    await expect(service.execute('uuid-1', 'Diretor' as any)).rejects.toThrow(ForbiddenException);
   });
 
   it('deve lançar NotFoundException se unidade não encontrada ao definir Diretor', async () => {
-    mockRepo.findById.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Docente' });
+    mockRepo.findById.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Docente' });
     mockTx.unidade.findUnique.mockResolvedValue(null);
-    await expect(service.execute(1, 'Diretor' as any, 99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-1', 'Diretor' as any, 'uuid-99')).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar ConflictException se unidade já tem diretor diferente', async () => {
-    mockRepo.findById.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Docente' });
-    mockTx.unidade.findUnique.mockResolvedValue({ unidade_id: 10, diretor_id: 99, diretor: { nome: 'Outro' } });
-    await expect(service.execute(1, 'Diretor' as any, 10)).rejects.toThrow(ConflictException);
+    mockRepo.findById.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Docente' });
+    mockTx.unidade.findUnique.mockResolvedValue({ unidade_id: 'uuid-10', diretor_id: 'uuid-99', diretor: { nome: 'Outro' } });
+    await expect(service.execute('uuid-1', 'Diretor' as any, 'uuid-10')).rejects.toThrow(ConflictException);
   });
 });

--- a/PGA-Backend/src/modules/user/services/delete-user.service.spec.ts
+++ b/PGA-Backend/src/modules/user/services/delete-user.service.spec.ts
@@ -20,32 +20,32 @@ describe('DeleteUserService', () => {
   it('deve lançar NotFoundException se usuário não encontrado', async () => {
     mockRepo.findById.mockResolvedValue(null);
 
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 
   it('deve lançar ConflictException se usuário vinculado a projetos ativos', async () => {
-    mockRepo.findById.mockResolvedValue({ pessoa_id: 1 });
+    mockRepo.findById.mockResolvedValue({ pessoa_id: 'uuid-1' });
     mockPrisma.projetoPessoa.count.mockResolvedValue(2);
 
-    await expect(service.execute(1)).rejects.toThrow(ConflictException);
+    await expect(service.execute('uuid-1')).rejects.toThrow(ConflictException);
   });
 
   it('deve lançar ConflictException se usuário é coordenador de cursos ativos', async () => {
-    mockRepo.findById.mockResolvedValue({ pessoa_id: 1 });
+    mockRepo.findById.mockResolvedValue({ pessoa_id: 'uuid-1' });
     mockPrisma.projetoPessoa.count.mockResolvedValue(0);
     mockPrisma.curso.count.mockResolvedValue(1);
 
-    await expect(service.execute(1)).rejects.toThrow(ConflictException);
+    await expect(service.execute('uuid-1')).rejects.toThrow(ConflictException);
   });
 
   it('deve executar a transação de exclusão quando sem conflitos', async () => {
-    const user = { pessoa_id: 1, nome: 'Test' };
+    const user = { pessoa_id: 'uuid-1', nome: 'Test' };
     mockRepo.findById.mockResolvedValue(user);
     mockPrisma.projetoPessoa.count.mockResolvedValue(0);
     mockPrisma.curso.count.mockResolvedValue(0);
     mockPrisma.$transaction.mockResolvedValue(user);
 
-    const result = await service.execute(1);
+    const result = await service.execute('uuid-1');
     expect(mockPrisma.$transaction).toHaveBeenCalled();
     expect(result).toBe(user);
   });

--- a/PGA-Backend/src/modules/user/services/get-user.service.spec.ts
+++ b/PGA-Backend/src/modules/user/services/get-user.service.spec.ts
@@ -15,13 +15,13 @@ describe('GetUserService', () => {
     const user = { pessoa_id: 1, nome: 'Test' };
     mockRepo.findById.mockResolvedValue(user);
 
-    const result = await service.execute(1);
+    const result = await service.execute('uuid-1');
     expect(result).toBe(user);
   });
 
   it('deve lançar NotFoundException se usuário não encontrado', async () => {
     mockRepo.findById.mockResolvedValue(null);
 
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });

--- a/PGA-Backend/src/modules/user/services/get-users-by-unit.service.spec.ts
+++ b/PGA-Backend/src/modules/user/services/get-users-by-unit.service.spec.ts
@@ -14,16 +14,16 @@ describe('GetUsersByUnitService', () => {
     const users = [{ pessoa_id: 1 }, { pessoa_id: 2 }];
     mockRepo.findByUnidadeId.mockResolvedValue(users);
 
-    const result = await service.execute(10);
+    const result = await service.execute('uuid-10');
 
-    expect(mockRepo.findByUnidadeId).toHaveBeenCalledWith(10);
+    expect(mockRepo.findByUnidadeId).toHaveBeenCalledWith('uuid-10');
     expect(result).toEqual(users);
   });
 
   it('deve retornar array vazio quando unidade não tem usuários', async () => {
     mockRepo.findByUnidadeId.mockResolvedValue([]);
 
-    const result = await service.execute(999);
+    const result = await service.execute('uuid-999');
     expect(result).toEqual([]);
   });
 });

--- a/PGA-Backend/src/modules/user/services/list-access-requests.service.spec.ts
+++ b/PGA-Backend/src/modules/user/services/list-access-requests.service.spec.ts
@@ -19,14 +19,14 @@ describe('ListAccessRequestsService', () => {
       { status: 'Pendente' },
       { status: 'Aprovada' },
     ]);
-    const result = await service.execute(1, 'Administrador' as any);
+    const result = await service.execute('uuid-1', 'Administrador' as any);
     expect(result.pendingRequests).toHaveLength(1);
     expect(result.processedRequests).toHaveLength(1);
   });
 
   it('deve retornar vazio para Diretor sem unidades', async () => {
     mockPrisma.pessoaUnidade.findMany.mockResolvedValue([]);
-    const result = await service.execute(1, 'Diretor' as any);
+    const result = await service.execute('uuid-1', 'Diretor' as any);
     expect(result.pendingRequests).toHaveLength(0);
     expect(result.processedRequests).toHaveLength(0);
   });
@@ -37,12 +37,12 @@ describe('ListAccessRequestsService', () => {
       { status: 'Pendente' },
       { status: 'Rejeitada' },
     ]);
-    const result = await service.execute(1, 'Diretor' as any);
+    const result = await service.execute('uuid-1', 'Diretor' as any);
     expect(result.pendingRequests).toHaveLength(1);
     expect(result.processedRequests).toHaveLength(1);
   });
 
   it('deve lançar ForbiddenException para tipo não autorizado', async () => {
-    await expect(service.execute(1, 'Docente' as any)).rejects.toThrow(ForbiddenException);
+    await expect(service.execute('uuid-1', 'Docente' as any)).rejects.toThrow(ForbiddenException);
   });
 });

--- a/PGA-Backend/src/modules/user/services/process-access-request.service.spec.ts
+++ b/PGA-Backend/src/modules/user/services/process-access-request.service.spec.ts
@@ -40,72 +40,72 @@ describe('ProcessAccessRequestService', () => {
 
   it('deve lançar BadRequestException se solicitação não encontrada', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(null);
-    await expect(service.execute(1, 1, 'Aprovada')).rejects.toThrow(BadRequestException);
+    await expect(service.execute('uuid-1', 'uuid-1', 'Aprovada')).rejects.toThrow(BadRequestException);
   });
 
   it('deve lançar BadRequestException se solicitação já processada', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue({ ...mockSolicitacao, status: 'Aprovada' });
-    await expect(service.execute(1, 1, 'Aprovada')).rejects.toThrow(BadRequestException);
+    await expect(service.execute('uuid-1', 'uuid-1', 'Aprovada')).rejects.toThrow(BadRequestException);
   });
 
   it('deve lançar UnauthorizedException se processador não encontrado', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
     mockPrisma.pessoa.findUnique.mockResolvedValue(null);
-    await expect(service.execute(1, 1, 'Aprovada')).rejects.toThrow(UnauthorizedException);
+    await expect(service.execute('uuid-1', 'uuid-1', 'Aprovada')).rejects.toThrow(UnauthorizedException);
   });
 
   it('deve lançar UnauthorizedException se processador sem permissão', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
-    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Docente' });
-    await expect(service.execute(1, 1, 'Aprovada')).rejects.toThrow(UnauthorizedException);
+    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Docente' });
+    await expect(service.execute('uuid-1', 'uuid-1', 'Aprovada')).rejects.toThrow(UnauthorizedException);
   });
 
   it('deve lançar UnauthorizedException se Diretor tentar processar outra unidade', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
-    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Diretor' });
+    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Diretor' });
     mockPrisma.unidade.findFirst.mockResolvedValue({ unidade_id: 99 }); // outra unidade
-    await expect(service.execute(1, 1, 'Aprovada')).rejects.toThrow(UnauthorizedException);
+    await expect(service.execute('uuid-1', 'uuid-1', 'Aprovada')).rejects.toThrow(UnauthorizedException);
   });
 
   it('deve lançar BadRequestException se Aprovada sem tipoUsuario', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
-    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Administrador' });
-    await expect(service.execute(1, 1, 'Aprovada')).rejects.toThrow(BadRequestException);
+    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Administrador' });
+    await expect(service.execute('uuid-1', 'uuid-1', 'Aprovada')).rejects.toThrow(BadRequestException);
   });
 
   it('deve rejeitar solicitação com sucesso', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
-    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Administrador' });
-    const result = await service.execute(1, 1, 'Rejeitada');
+    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Administrador' });
+    const result = await service.execute('uuid-1', 'uuid-1', 'Rejeitada');
     expect(result.success).toBe(true);
   });
 
   it('deve aprovar solicitação e criar usuário Docente', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
-    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Administrador' });
-    mockPrisma.pessoa.create.mockResolvedValue({ pessoa_id: 10, email: 'joao@test.com' });
+    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Administrador' });
+    mockPrisma.pessoa.create.mockResolvedValue({ pessoa_id: 'uuid-10', email: 'joao@test.com' });
     mockPrisma.pessoaUnidade.create.mockResolvedValue({});
     mockSendApproved.execute.mockResolvedValue(undefined);
-    const result = await service.execute(1, 1, 'Aprovada', 'Docente' as any);
+    const result = await service.execute('uuid-1', 'uuid-1', 'Aprovada', 'Docente' as any);
     expect(result.success).toBe(true);
   });
 
   it('deve aprovar solicitação e criar usuário Diretor', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
-    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Administrador' });
+    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Administrador' });
     mockPrisma.unidade.findUnique.mockResolvedValue({ diretor_id: null, nome_unidade: 'X' });
-    mockPrisma.pessoa.create.mockResolvedValue({ pessoa_id: 10 });
+    mockPrisma.pessoa.create.mockResolvedValue({ pessoa_id: 'uuid-10' });
     mockPrisma.pessoaUnidade.create.mockResolvedValue({});
     mockPrisma.unidade.update.mockResolvedValue({});
     mockSendApproved.execute.mockResolvedValue(undefined);
-    const result = await service.execute(1, 1, 'Aprovada', 'Diretor' as any);
+    const result = await service.execute('uuid-1', 'uuid-1', 'Aprovada', 'Diretor' as any);
     expect(result.success).toBe(true);
   });
 
   it('deve lançar ConflictException se unidade já tem diretor', async () => {
     mockPrisma.solicitacaoAcesso.findUnique.mockResolvedValue(mockSolicitacao);
-    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 1, tipo_usuario: 'Administrador' });
-    mockPrisma.unidade.findUnique.mockResolvedValue({ diretor_id: 5, nome_unidade: 'X' });
-    await expect(service.execute(1, 1, 'Aprovada', 'Diretor' as any)).rejects.toThrow(ConflictException);
+    mockPrisma.pessoa.findUnique.mockResolvedValue({ pessoa_id: 'uuid-1', tipo_usuario: 'Administrador' });
+    mockPrisma.unidade.findUnique.mockResolvedValue({ diretor_id: 'uuid-5', nome_unidade: 'X' });
+    await expect(service.execute('uuid-1', 'uuid-1', 'Aprovada', 'Diretor' as any)).rejects.toThrow(ConflictException);
   });
 });

--- a/PGA-Backend/src/modules/user/services/update-user.service.spec.ts
+++ b/PGA-Backend/src/modules/user/services/update-user.service.spec.ts
@@ -14,9 +14,9 @@ describe('UpdateUserService', () => {
     const updated = { pessoa_id: 1, nome: 'Novo Nome' };
     mockRepo.update.mockResolvedValue(updated);
 
-    const result = await service.execute(1, { nome: 'Novo Nome' });
+    const result = await service.execute('uuid-1', { nome: 'Novo Nome' });
 
-    expect(mockRepo.update).toHaveBeenCalledWith(1, { nome: 'Novo Nome' });
+    expect(mockRepo.update).toHaveBeenCalledWith('uuid-1', { nome: 'Novo Nome' });
     expect(result).toBe(updated);
   });
 });

--- a/PGA-Backend/src/modules/workloadHAE/workload-hae.spec.ts
+++ b/PGA-Backend/src/modules/workloadHAE/workload-hae.spec.ts
@@ -41,12 +41,12 @@ describe('FindOneWorkloadHaeService', () => {
 
   it('deve retornar a carga HAE encontrada', async () => {
     mockRepo.findOne.mockResolvedValue({ workload_hae_id: 1 });
-    expect(await service.execute(1)).toEqual({ workload_hae_id: 1 });
+    expect(await service.execute('uuid-1')).toEqual({ workload_hae_id: 1 });
   });
 
-  it('deve lançar NotFoundException se não encontrada', async () => {
+  it('deve lançar NotFoundException se não encontrado', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -57,12 +57,12 @@ describe('UpdateWorkloadHaeService', () => {
   it('deve atualizar e retornar a carga HAE', async () => {
     mockRepo.findOne.mockResolvedValue({ workload_hae_id: 1 });
     mockRepo.update.mockResolvedValue({ id: 1, descricao: 'Novo' });
-    expect(((await service.execute(1, { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
+    expect(((await service.execute('uuid-1', { descricao: 'Novo' } as any)) as any).descricao).toBe('Novo');
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99, {} as any)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99', {} as any)).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -74,19 +74,19 @@ describe('DeleteWorkloadHaeService', () => {
     mockRepo.findOne.mockResolvedValue({ workload_hae_id: 1 });
     mockPrisma.projetoPessoa.count.mockResolvedValue(0);
     mockRepo.softDelete.mockResolvedValue({ workload_hae_id: 1 });
-    await service.execute(1);
-    expect(mockRepo.softDelete).toHaveBeenCalledWith(1);
+    await service.execute('uuid-1');
+    expect(mockRepo.softDelete).toHaveBeenCalledWith('uuid-1');
   });
 
   it('deve lançar ConflictException se vínculo em uso', async () => {  
     mockRepo.findOne.mockResolvedValue({ workload_hae_id: 1 });
     mockPrisma.projetoPessoa.count.mockResolvedValue(3);
     const { ConflictException } = require('@nestjs/common');
-    await expect(service.execute(1)).rejects.toThrow(ConflictException);
+    await expect(service.execute('uuid-1')).rejects.toThrow(ConflictException);
   });
 
   it('deve lançar NotFoundException se não encontrada', async () => {
     mockRepo.findOne.mockResolvedValue(null);
-    await expect(service.execute(99)).rejects.toThrow(NotFoundException);
+    await expect(service.execute('uuid-99')).rejects.toThrow(NotFoundException);
   });
 });


### PR DESCRIPTION
Refactor tests to replace numeric IDs with UUIDs for user, regional, thematic axis, project, and workload entities, ensuring consistency across repository queries and assertions.